### PR TITLE
Add how to reuse a chart multiple times in dependency doc

### DIFF
--- a/content/en/docs/helm/helm_dependency.md
+++ b/content/en/docs/helm/helm_dependency.md
@@ -55,6 +55,16 @@ If the dependency chart is retrieved locally, it is not required to have the
 repository added to helm by "helm add repo". Version matching is also supported
 for this case.
 
+If you want to reuse a chart multiple times you have to add an alias for it.
+    
+    # Chart.yaml
+    dependencies:
+    - name: nginx
+      version: "1.2.3"
+      repository: "file://../dependency_chart/nginx"
+      alias: nginx-alias
+
+
 
 ### Options
 


### PR DESCRIPTION
Why this PR:
I recently searched for a solution how to reuse a chart multiple times. Unfortunately the documentation about how to add dependencies had no such information.
I found something about it in the Chart.yml keyword  description.
In my opinion this should also be mentioned in the documention about how to add dependencies because this is the first place where people start looking.